### PR TITLE
Benchie source restructured and made human-readable

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -7,7 +7,7 @@
   },
   "files": {
     "ignoreUnknown": false,
-    "ignore": ["dist"]
+    "ignore": ["dist", "cdn"]
   },
   "formatter": {
     "enabled": true,

--- a/cdn/.gitignore
+++ b/cdn/.gitignore
@@ -1,0 +1,1 @@
+benchie.min.js

--- a/cdn/README.md
+++ b/cdn/README.md
@@ -1,0 +1,3 @@
+```shell
+bun run build-benchie.ts
+```

--- a/cdn/benchie.js
+++ b/cdn/benchie.js
@@ -1,8 +1,14 @@
+/* 
+
+// Define before:
+
 const $__CDN_LIST = [
   window.location.origin,
   // ...
   // ...
 ];
+
+*/
 
 /**!
  * PathScale CONFIDENTIAL

--- a/cdn/benchie.js
+++ b/cdn/benchie.js
@@ -72,6 +72,15 @@ async function resolveElementResource(el, cdnBase) {
  * Helper to convert <meta name="pathscale-cdn"> into a real <link>
  */
 async function resolveMetaCdnElement(metaEl, cdnBase) {
+  // Ensure the element is the expected <meta name="pathscale-cdn">
+  if (
+    !(metaEl instanceof Element) ||
+    metaEl.tagName !== "META" ||
+    metaEl.getAttribute("name") !== "pathscale-cdn"
+  ) {
+    return;
+  }
+
   const content = metaEl.getAttribute('content');
   if (!content) return;
 

--- a/cdn/benchie.js
+++ b/cdn/benchie.js
@@ -47,6 +47,12 @@ async function fetchAndCache(url, base) {
 }
 
 /**
+ * Make `fetchAndCache` globally available via `window.t`
+ * Useful for debugging or using manually from external scripts
+ */
+window.t = fetchAndCache
+
+/**
  * Replaces `data-href` and `data-src` with actual working `href`/`src`
  * using fetchAndCache.
  */
@@ -81,6 +87,9 @@ window.addEventListener("DOMContentLoaded", async function () {
 
   $__CDN = await Promise.race(cdnRace);
   abortController.abort();
+
+  // Expose the value to global scope so it won't be renamed
+  window.$__CDN = $__CDN;
 
   // Find elements with data-src and data-href and update them
   const dataSrcElements = Array.from(document.querySelectorAll("[data-src]"));

--- a/cdn/benchie.js
+++ b/cdn/benchie.js
@@ -1,0 +1,113 @@
+const $__CDN_LIST = [
+  window.location.origin,
+  // ...
+  // ...
+];
+
+/**!
+ * PathScale CONFIDENTIAL
+ * __
+ * [2025] PathScale PTE Ltd
+ * All Rights Reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains the property of PathScale PTE Ltd.
+ * The intellectual and technical concepts contained herein are proprietary to PathScale PTE Ltd
+ * and may be covered by Singapore and Foreign Patents, patents in process, and are protected
+ * by trade secret or copyright law. Dissemination of this information or reproduction of this
+ * material is strictly forbidden unless prior written permission is obtained from PathScale PTE Ltd.
+ */
+
+let $__CDN;
+
+/**
+ * Fetches a resource by URL and caches it using the Cache API.
+ * Returns a blob URL.
+ */
+async function fetchAndCache(url, base) {
+  const absoluteUrl = new URL(url, base).href;
+
+  if (!window.caches) return absoluteUrl;
+
+  const cache = await window.caches.open("v1");
+  let response = await cache.match(url);
+
+  if (!response) {
+    response = await fetch(absoluteUrl, { method: "GET", cache: "no-store" });
+    await cache.put(url, response.clone());
+  }
+
+  const blob = await response.blob();
+  return URL.createObjectURL(blob);
+}
+
+/**
+ * Replaces `data-href` and `data-src` with actual working `href`/`src`
+ * using fetchAndCache.
+ */
+async function resolveElementResource(el, cdnBase) {
+  if (el.dataset.href) {
+    if (el.href) URL.revokeObjectURL(el.href);
+    el.setAttribute("href", await fetchAndCache(el.dataset.href, cdnBase));
+  }
+
+  if (el.dataset.src) {
+    if (el.src) URL.revokeObjectURL(el.src);
+    el.setAttribute("src", await fetchAndCache(el.dataset.src, cdnBase));
+  }
+}
+
+window.addEventListener("DOMContentLoaded", async function () {
+  const abortController = new AbortController();
+
+  // Ping all CDNs in parallel — the first to respond wins
+  const cdnRace = $__CDN_LIST.map(url =>
+    (async function tryHead(u, signal) {
+      await fetch(u, {
+        signal,
+        cache: "no-store",
+        mode: "no-cors",
+        method: "HEAD",
+        body: null
+      });
+      return u;
+    })(url, abortController.signal)
+  );
+
+  $__CDN = await Promise.race(cdnRace);
+  abortController.abort();
+
+  // Find elements with data-src and data-href and update them
+  const dataSrcElements = Array.from(document.querySelectorAll("[data-src]"));
+  const dataHrefElements = Array.from(document.querySelectorAll("[data-href]"));
+
+  const srcRewrites = dataSrcElements.map(el =>
+    fetchAndCache(el.dataset.src, $__CDN).then(blobUrl => el.setAttribute("src", blobUrl))
+  );
+
+  const hrefRewrites = dataHrefElements.map(el =>
+    fetchAndCache(el.dataset.href, $__CDN).then(blobUrl => el.setAttribute("href", blobUrl))
+  );
+
+  await Promise.all(srcRewrites);
+  await Promise.all(hrefRewrites);
+
+  // Watch for DOM changes and apply blob URLs if needed
+  new MutationObserver(async (mutations) => {
+    for await (const mutation of mutations) {
+      if (mutation.type === "attributes") {
+        await resolveElementResource(mutation.target, $__CDN);
+      } else if (mutation.type === "childList") {
+        for await (const node of mutation.addedNodes) {
+          if ("dataset" in node) {
+            await resolveElementResource(node, $__CDN);
+          }
+        }
+      }
+    }
+  }).observe(document, {
+    attributes: true,
+    attributeFilter: ["data-src", "data-href"],
+    childList: true,
+    subtree: true
+  });
+});

--- a/cdn/benchie.js
+++ b/cdn/benchie.js
@@ -10,7 +10,7 @@ const $__CDN_LIST = [
 
 */
 
-/**!
+/*!*
  * PathScale CONFIDENTIAL
  * __
  * [2025] PathScale PTE Ltd

--- a/cdn/build-benchie.ts
+++ b/cdn/build-benchie.ts
@@ -1,0 +1,9 @@
+await Bun.build({
+  entrypoints: ['benchie.js'],
+  outdir: '.',                
+  minify: true,
+  target: 'browser',
+  naming: "[dir]/[name].min.[ext]",
+});
+
+console.log('✅ benchie.min.js built using Bun');

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -61,8 +61,9 @@ const template = ({ attributes, files, meta, publicPath, title }) => {
   const links = (files.css || [])
     .map(({ fileName }) => {
       const file = addVersion(fileName);
-      const attrs = makeHtmlAttributes(attributes.link);
-      return `<link href="${publicPath}${file}" rel="stylesheet"${attrs}>`;
+      const href = `${publicPath}${file}`;
+      // It will be replaces by <link rel="stylesheet" href="..."> by Benchie in browser runtime
+      return `<meta name="pathscale-cdn" content="tag=link, rel=stylesheet, href=${href}">`;
     })
     .join("\n");
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import zlib from "node:zlib";
@@ -112,15 +113,7 @@ const template = ({ attributes, files, meta, publicPath, title }) => {
     const $__CDN_LIST = [
       window.location.origin
     ];
-    /**!
-     * PathScale CONFIDENTIAL
-     * __
-     * [2020] PathScale PTE Ltd
-     * All Rights Reserved.
-     *
-     * NOTICE:  All information contained herein is, and remains the property of PathScale PTE Ltd. The intellectual and technical concepts contained herein are proprietary to PathScale PTE Ltd and may be covered by Singapore and Foreign Patents, patents in process, and are protected by trade secret or copyright law. Dissemination of this information or reproduction of this material is strictly forbidden unless prior written permission is obtained from PathScale PTE Ltd.
-     */
-    let $__CDN;async function t(t,e){const a=new URL(t,e).href;if(!window.caches)return a;const r=await window.caches.open("v1");let s=await r.match(t);s||(s=await fetch(a,{method:"GET",cache:"no-store"}),await r.put(t,s.clone()));const c=await s.blob();return URL.createObjectURL(c)}async function e(e,a){e.dataset.href&&(e.href&&URL.revokeObjectURL(e.href),e.setAttribute("href",await t(e.dataset.href,a))),e.dataset.src&&(e.src&&URL.revokeObjectURL(e.src),e.setAttribute("src",await t(e.dataset.src,a)))}window.addEventListener("DOMContentLoaded",(async function(){const a=new AbortController,r=$__CDN_LIST.map(t=>async function(t,e){return await fetch(t,{signal:e,cache:"no-store",mode:"no-cors",method:"HEAD",body:null}),t}(t,a.signal));$__CDN=await Promise.race(r),a.abort();const s=Array.from(document.querySelectorAll("[data-src]")),c=Array.from(document.querySelectorAll("[data-href]")),o=s.map(async e=>{const a=e.dataset.src;e.setAttribute("src",await t(a,$__CDN))}),n=c.map(async e=>{const a=e.dataset.href;e.setAttribute("href",await t(a,$__CDN))});await Promise.all(o),await Promise.all(n),new MutationObserver(async t=>{for await(const a of t)if("attributes"===a.type)await e(a.target,$__CDN);else if("childList"===a.type)for await(const t of a.addedNodes)"dataset"in t&&await e(t,$__CDN)}).observe(document,{attributes:!0,attributeFilter:["data-src","data-href"],childList:!0,subtree:!0})}));
+    ${fs.readFileSync("cdn/benchie.min.js", "utf8").trim()}
     </script>
     ${links}
   </head>


### PR DESCRIPTION
Before making any changes to the CDN loading/replacing logic, I reconstructed the original `Benchie` code into a readable source version.

The code was restored manually by carefully reading and understanding the minified output.

All related files are located in the `cdn/` directory.

To generate the minified version, run the following:
```
cd cdn && bun run build-benchie.ts
```


